### PR TITLE
New download code to get the latest NOAA monthly average flask data

### DIFF
--- a/.run_ginput_template.py
+++ b/.run_ginput_template.py
@@ -3,7 +3,7 @@ import argparse
 
 from ginput.priors import acos_interface as aci, tccon_priors, map_maker, mlo_smo_prep, automation
 from ginput.mod_maker import mod_maker
-from ginput.download import get_GEOS5
+from ginput.download import get_GEOS5, get_NOAA_flask_data
 
 
 def parse_args():
@@ -47,6 +47,9 @@ def parse_args():
 
     get_rlg5_parser = subparsers.add_parser('get-rl-g5', help='Download GEOS5 FP or FP-IT data for spectra in a runlog')
     get_GEOS5.parse_runlog_args(get_rlg5_parser)
+
+    get_noaa_parser = subparsers.add_parser("getnoaa",help="Download NOAA flask data")
+    get_NOAA_flask_data.parse_args(get_noaa_parser)
 
     map_parser = subparsers.add_parser('map', help='Generate .map (a priori) files.')
     map_maker.parse_cl_args(map_parser)

--- a/doc/source/ginput_usage/updating_noaa.md
+++ b/doc/source/ginput_usage/updating_noaa.md
@@ -15,6 +15,9 @@ The repo includes NOAA flask data from 2018 and earlier in the {file}`ginput/dat
 
 `ginput` natively reads the monthly average flask files available from [NOAA GML](https://gml.noaa.gov/dv/data/index.php?frequency=Monthly%2BAverages&type=Flask). To download more recent files from that link, select the gas(es) of interest in the "Parameter" column (carbon dioxide, nitrous oxide, or methane), then in the "Site" column select "MLO" (Mauna Loa) and "SMO" (American Samoa). For each site, this should provide exactly one file for download in the table at the bottom of the page. Save both the MLO and SMO files to your system.
 
+
+A utility program is included in ginput/download/ to directly download the latest NOAA monthly averaged flask data.
+
 ### Generating .vmr files
 
 In ginput v1.1.7, it is only possible to pass alternative NOAA files via the command line for the satellite subcommands (`oco`, `gosat`, `geocarb`). Because of the need to potentially pass multiple gases' files for regular {file}`.vmr` files, supporting this for the `vmr` and `rlvmr` subcommands requires additional development, but is planned for a future ginput version.

--- a/doc/source/ginput_usage/updating_noaa.md
+++ b/doc/source/ginput_usage/updating_noaa.md
@@ -16,7 +16,9 @@ The repo includes NOAA flask data from 2018 and earlier in the {file}`ginput/dat
 `ginput` natively reads the monthly average flask files available from [NOAA GML](https://gml.noaa.gov/dv/data/index.php?frequency=Monthly%2BAverages&type=Flask). To download more recent files from that link, select the gas(es) of interest in the "Parameter" column (carbon dioxide, nitrous oxide, or methane), then in the "Site" column select "MLO" (Mauna Loa) and "SMO" (American Samoa). For each site, this should provide exactly one file for download in the table at the bottom of the page. Save both the MLO and SMO files to your system.
 
 
-A utility program is included in ginput/download/ to directly download the latest NOAA monthly averaged flask data.
+A utility program is included in ginput/download/ to directly download the latest NOAA monthly averaged flask data, it is available via `run_ginput.py`. See usage info with:
+
+`./run_ginput.py getnoaa -h`
 
 ### Generating .vmr files
 

--- a/ginput/download/get_NOAA_flask_data.py
+++ b/ginput/download/get_NOAA_flask_data.py
@@ -1,0 +1,67 @@
+import os
+import argparse
+import urllib.request
+
+
+def get_NOAA_flask_data(
+    out_dir: str,
+    site_list: list[str] = ["mlo", "smo"],
+    gas_list: list[str] = ["co2", "ch4", "co", "n2o"],
+) -> None:
+    """
+    Download monthly flask data from NOAA GML for gases listed in gas_list and sites listed in site_list
+
+    https://gml.noaa.gov/dv/data/index.php?frequency=Monthly%2BAverages&amp;type=Flask
+
+    :param out_dir: full path to the directory where the files will be downloaded
+
+    :param site_list: list of NOAA GML site identifiers (e.g. mlo for mauna loa, smo for samoa)
+
+    :param gas_list: list of gases for which data will be downloaded
+    """
+    site_list = [i.lower() for i in site_list]
+    gas_list = [i.lower() for i in gas_list]
+
+    # the ginput data files may use a site abbreviation that differs from the NOAA site identifier
+    # use the site_map dictionary to map between the NOAA abbreviation and the ginput abbreviation
+    site_map = {"mlo": "ML"}
+    for site in site_list:
+        if site not in site_map:
+            site_map[site] = site.upper()
+
+    URL_FMT = "https://gml.noaa.gov/aftp/data/trace_gases/{gas}/flask/surface/txt/{gas}_{site}_surface-flask_1_ccgg_month.txt"
+
+    FILE_FMT = "{site}_monthly_obs_{gas}.txt"
+
+    for site in site_list:
+        for gas in gas_list:
+            file_url = URL_FMT.format(gas=gas, site=site)
+            local_filename = os.path.join(out_dir, FILE_FMT.format(gas=gas, site=site_map[site]))
+            urllib.request.urlretrieve(
+                file_url,
+                filename=local_filename,
+            )
+            print(f"{file_url} downloaded to {local_filename}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o", "--out-dir", help="full path to the directory where files will be downloaded"
+    )
+    parser.add_argument(
+        "-u",
+        "--update",
+        action="store_true",
+        help="if given, set --out-dir to the ginput data directory",
+    )
+    args = parser.parse_args()
+
+    if args.update:
+        args.out_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+
+    get_NOAA_flask_data(args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/ginput/download/get_NOAA_flask_data.py
+++ b/ginput/download/get_NOAA_flask_data.py
@@ -3,7 +3,7 @@ import argparse
 import urllib.request
 
 
-def get_NOAA_flask_data(
+def get_noaa_flask_data(
     out_dir: str,
     site_list: list[str] = ["mlo", "smo"],
     gas_list: list[str] = ["co2", "ch4", "co", "n2o"],
@@ -60,7 +60,7 @@ def main():
     if args.update:
         args.out_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
 
-    get_NOAA_flask_data(args.out_dir)
+    get_noaa_flask_data(args.out_dir)
 
 
 if __name__ == "__main__":

--- a/ginput/download/get_NOAA_flask_data.py
+++ b/ginput/download/get_NOAA_flask_data.py
@@ -7,6 +7,7 @@ def get_noaa_flask_data(
     out_dir: str,
     site_list: list[str] = ["mlo", "smo"],
     gas_list: list[str] = ["co2", "ch4", "co", "n2o"],
+    update: bool = False,
 ) -> None:
     """
     Download monthly flask data from NOAA GML for gases listed in gas_list and sites listed in site_list
@@ -18,7 +19,12 @@ def get_noaa_flask_data(
     :param site_list: list of NOAA GML site identifiers (e.g. mlo for mauna loa, smo for samoa)
 
     :param gas_list: list of gases for which data will be downloaded
+
+    :param update: if True, will save the file under ginput data directory, overwriting existing NOAA files there
     """
+    if update:
+        out_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+
     site_list = [i.lower() for i in site_list]
     gas_list = [i.lower() for i in gas_list]
 
@@ -44,24 +50,48 @@ def get_noaa_flask_data(
             print(f"{file_url} downloaded to {local_filename}")
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def parse_args(parser=None):
+    description = "Download NOAA surface flask data"
+    if parser is None:
+        parser = argparse.ArgumentParser(description=description)
+        am_i_main = True
+    else:
+        parser.description = description
+        am_i_main = False
+
     parser.add_argument(
-        "-o", "--out-dir", help="full path to the directory where files will be downloaded"
+        "-o",
+        "--out-dir",
+        help="full path to the directory where files will be downloaded",
+    )
+    parser.add_argument(
+        "-s",
+        "--site-list",
+        nargs="+",
+        help="NOAA site abbreviations e.g. smo for samoa",
+        default=["smo", "mlo"],
+    )
+    parser.add_argument(
+        "-g",
+        "--gas-list",
+        nargs="+",
+        help="Gas names",
+        default=["co2", "ch4", "co", "n2o"],
     )
     parser.add_argument(
         "-u",
         "--update",
         action="store_true",
-        help="if given, set --out-dir to the ginput data directory",
+        help="if given, set --out-dir to the ginput data directory, will overwrite NOAA files already there",
     )
-    args = parser.parse_args()
 
-    if args.update:
-        args.out_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
-
-    get_noaa_flask_data(args.out_dir)
+    if am_i_main:
+        args = vars(parser.parse_args())
+        return args
+    else:
+        parser.set_defaults(driver_fxn=get_noaa_flask_data)
 
 
 if __name__ == "__main__":
-    main()
+    arguments = parse_args()
+    get_noaa_flask_data(**arguments)

--- a/ginput/download/get_NOAA_flask_data.py
+++ b/ginput/download/get_NOAA_flask_data.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 import urllib.request
+import urllib.error
 
 
 def get_noaa_flask_data(
@@ -43,11 +44,15 @@ def get_noaa_flask_data(
         for gas in gas_list:
             file_url = URL_FMT.format(gas=gas, site=site)
             local_filename = os.path.join(out_dir, FILE_FMT.format(gas=gas, site=site_map[site]))
-            urllib.request.urlretrieve(
-                file_url,
-                filename=local_filename,
-            )
-            print(f"{file_url} downloaded to {local_filename}")
+            try:
+                urllib.request.urlretrieve(
+                    file_url,
+                    filename=local_filename,
+                )
+            except urllib.error.HTTPError as e:
+                print(f"Could not download {file_url}: {e.__str__()}")
+            else:
+                print(f"{file_url} downloaded to {local_filename}")
 
 
 def parse_args(parser=None):


### PR DESCRIPTION
Added a code in ginput/download to get the latest monthly averaged flask data from NOAA website.
A caveat is it assumes the URL structure won't change.

Runs with:

`python get_NOAA_flask_data.py -o out_dir`

Haven't added an entry point from run_ginput but I can add it if you think that'd be useful and update the doc accordingly.